### PR TITLE
FOLIO-1549 Use stripes framework 1.0

### DIFF
--- a/VendorSearch/VendorSearch.js
+++ b/VendorSearch/VendorSearch.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Button from '@folio/stripes-components/lib/Button';
-import Icon from '@folio/stripes-components/lib/Icon';
+import { Button, Icon } from '@folio/stripes/components';
 import className from 'classnames';
 
 import css from './VendorSearch.css';

--- a/VendorSearch/VendorSearchModal.js
+++ b/VendorSearch/VendorSearchModal.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Vendors from '@folio/vendors/src/Main';
-import Modal from '@folio/stripes-components/lib/Modal';
+import { Modal } from '@folio/stripes/components';
 
 import css from './VendorSearch.css';
 

--- a/package.json
+++ b/package.json
@@ -21,23 +21,21 @@
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^3.2.1",
-    "@folio/stripes-connect": "^3.1.2",
-    "@folio/stripes-core": "^2.7.0",
+    "@folio/stripes": "^1.0.0",
     "babel-eslint": "^9.0.0",
     "eslint": "^5.6.0",
     "react": "^16.5.1",
-    "react-dom": "^16.5.1"
+    "react-dom": "^16.5.1",
+    "react-redux": "^5.0.7",
+    "redux": "^4.0.0"
   },
   "dependencies": {
-    "@folio/stripes-components": "^3.0.0",
-    "@folio/stripes-logger": "^0.0.2",
-    "@folio/vendors": "^1.0.0",
+    "@folio/vendors": "^1.1.0",
     "classnames": "^2.2.5",
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
-    "@folio/stripes-connect": "^3.1.2",
-    "@folio/stripes-core": "^2.7.0",
+    "@folio/stripes": "^1.0.0",
     "react": "*"
   }
 }


### PR DESCRIPTION
This updates `stripes-*` dependencies and their corresponding imports to make use of stripes framework v1.0.0.

Will unblock https://github.com/folio-org/ui-orders/pull/33

Needs v1.1.0 release.